### PR TITLE
add radar for map writer.

### DIFF
--- a/src/main/java/com/flansmod/common/driveables/DriveableType.java
+++ b/src/main/java/com/flansmod/common/driveables/DriveableType.java
@@ -205,7 +205,12 @@ public class DriveableType extends InfoType
 	public String	flareSound	= "";
 	public int 		timeFlareUsing = 1;
 
-	
+	// radar (for mapwriter)
+	/** The height of the entity that can be detected by radar.<br>
+	 * -1 = It does not detect.<br> */
+	public int radarDetectableAltitude = -1;
+	public boolean stealth = false;
+
     /** Barrel Recoil stuff */
     public float recoilDist = 5F;
     public float recoilTime = 5F;
@@ -872,6 +877,12 @@ public class DriveableType extends InfoType
 				emitter.velocity.scale(1.0f / 16.0f);
 				emitters.add(emitter);
 			}
+
+			// radar (for mapwriter)
+			else if(split[0].equals("RadarDetectableAltitude"))
+				radarDetectableAltitude = Integer.parseInt(split[1]);
+			else if(split[0].equals("Stealth"))
+				stealth = split[1].equals("True");
 		}
 		catch (Exception e)
 		{


### PR DESCRIPTION
レーダー機能として、ミニマップに敵航空機が映るように変更。

RadarDetectableAltitude 10
これを設定した機体は、この高さより高い高度にいる、味方以外のプレイヤーが乗った機体を検出する。
マイナス値は無効。
0は有効で地上の機体も検出できるかも？
敵プレイヤーが乗ったエンティティはなんでも検出する。
例えばボートに乗って落下しても検出されるし、他のMODの機体に乗っても検出する。

Stealth True
これを設定した機体は、レーダーに表示されない。
